### PR TITLE
Dynamic metric labels

### DIFF
--- a/metrics.coffee
+++ b/metrics.coffee
@@ -81,14 +81,14 @@ module.exports = Metrics =
 	set : (key, value, sampleRate = 1)->
 		console.log("counts are not currently supported")
 
-	inc : (key, sampleRate = 1, opts = {})->
+	inc : (key, sampleRate = 1, opts = {},help=null)->
 		key = Metrics.buildPromKey(key)
 		opts.app = appname
 		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Counter({
 				name: key,
-				help: key, 
+				help: help || key 
 				labelNames: Object.keys(opts)
 			})
 
@@ -96,28 +96,28 @@ module.exports = Metrics =
 		if process.env['DEBUG_METRICS']
 			console.log("doing inc", key, opts)
 
-	count : (key, count, sampleRate = 1, opts = {})->
+	count : (key, count, sampleRate = 1, opts = {},help=null)->
 		key = Metrics.buildPromKey(key)
 		opts.app = appname
 		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Counter({
 				name: key,
-				help: key, 
+				help: help || key
 				labelNames: Object.keys(opts)
 			})
 		promMetrics[key].inc(opts, count)
 		if process.env['DEBUG_METRICS']
 			console.log("doing count/inc", key, opts)
 
-	timing: (key, timeSpan, sampleRate, opts = {})->
+	timing: (key, timeSpan, sampleRate, opts = {},help=null)->
 		key = Metrics.buildPromKey("timer_" + key)
 		opts.app = appname
 		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Summary({
 				name: key,
-				help: key,
+				help: help || key,
 				maxAgeSeconds: 600,
 				ageBuckets: 10,
 				labelNames: Object.keys(opts)
@@ -139,28 +139,28 @@ module.exports = Metrics =
 			Metrics.timing(this.key, timeSpan, this.sampleRate, this.opts)
 			return timeSpan
 
-	gauge : (key, value, sampleRate = 1, opts = {})->
+	gauge : (key, value, sampleRate = 1, opts = {},help=null)->
 		key = Metrics.buildPromKey(key)
 		opts.app = appname
 		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Gauge({
 				name: key,
-				help: key, 
+				help: help || key, 
 				labelNames: Object.keys(opts)
 			})
 		promMetrics[key].set(opts, this.sanitizeValue(value))
 		if process.env['DEBUG_METRICS']
 			console.log("doing gauge", key, opts)
 			
-	globalGauge: (key, value, sampleRate = 1, opts = {})->
+	globalGauge: (key, value, sampleRate = 1, opts = {},help=null)->
 		key = Metrics.buildPromKey(key)
 		opts.app = appname
 		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Gauge({
 				name: key,
-				help: key, 
+				help: help || key, 
 				labelNames:  Object.keys(opts)
 			})
 		promMetrics[key].set(opts,this.sanitizeValue(value))

--- a/metrics.coffee
+++ b/metrics.coffee
@@ -83,42 +83,45 @@ module.exports = Metrics =
 
 	inc : (key, sampleRate = 1, opts = {})->
 		key = Metrics.buildPromKey(key)
+		opts.app = appname
+		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Counter({
 				name: key,
 				help: key, 
-				labelNames: ['app','host','status','method', 'path']
+				labelNames: Object.keys(opts)
 			})
-		opts.app = appname
-		opts.host = hostname
+
 		promMetrics[key].inc(opts)
 		if process.env['DEBUG_METRICS']
 			console.log("doing inc", key, opts)
 
-	count : (key, count, sampleRate = 1)->
+	count : (key, count, sampleRate = 1, opts = {})->
 		key = Metrics.buildPromKey(key)
+		opts.app = appname
+		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Counter({
 				name: key,
 				help: key, 
-				labelNames: ['app','host']
+				labelNames: Object.keys(opts)
 			})
-		promMetrics[key].inc({app: appname, host: hostname}, count)
+		promMetrics[key].inc(opts, count)
 		if process.env['DEBUG_METRICS']
 			console.log("doing count/inc", key, opts)
 
 	timing: (key, timeSpan, sampleRate, opts = {})->
 		key = Metrics.buildPromKey("timer_" + key)
+		opts.app = appname
+		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Summary({
 				name: key,
 				help: key,
 				maxAgeSeconds: 600,
 				ageBuckets: 10,
-				labelNames: ['app', 'host', 'path', 'status_code', 'method', 'collection', 'query']
+				labelNames: Object.keys(opts)
 			})
-		opts.app = appname
-		opts.host = hostname
 		promMetrics[key].observe(opts, timeSpan)
 		if process.env['DEBUG_METRICS']
 			console.log("doing timing", key, opts)
@@ -136,27 +139,31 @@ module.exports = Metrics =
 			Metrics.timing(this.key, timeSpan, this.sampleRate, this.opts)
 			return timeSpan
 
-	gauge : (key, value, sampleRate = 1)->
+	gauge : (key, value, sampleRate = 1, opts = {})->
 		key = Metrics.buildPromKey(key)
+		opts.app = appname
+		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Gauge({
 				name: key,
 				help: key, 
-				labelNames: ['app','host']
+				labelNames: Object.keys(opts)
 			})
-		promMetrics[key].set({app: appname, host: hostname}, this.sanitizeValue(value))
+		promMetrics[key].set(opts, this.sanitizeValue(value))
 		if process.env['DEBUG_METRICS']
 			console.log("doing gauge", key, opts)
 			
-	globalGauge: (key, value, sampleRate = 1)->
+	globalGauge: (key, value, sampleRate = 1, opts = {})->
 		key = Metrics.buildPromKey(key)
+		opts.app = appname
+		opts.host = hostname
 		if !promMetrics[key]?
 			promMetrics[key] = new prom.Gauge({
 				name: key,
 				help: key, 
-				labelNames: ['app','host']
+				labelNames:  Object.keys(opts)
 			})
-		promMetrics[key].set({app: appname},this.sanitizeValue(value))
+		promMetrics[key].set(opts,this.sanitizeValue(value))
 
 	mongodb: require "./mongodb"
 	http: require "./http"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The Prometheus client needs to know the names of the labels to be associated with a metric at the point that it creates the metric object. Previously a fixed list was used for each metric type. This pull request dynamically worked out the metric labels based on the `opts` array passed on the first attempt to write to the metric. As before, `app` and `host` are added automatically.

In addition, we add an optional `help` parameter which allows a descriptive string to be attached to the metric on first write. This will appear in the information displayed at /metrics. (Unfortunately this does not appear to be picked up by the stackdriver-prometheus integration at this stage.)