### PR TITLE
allow options for count

### DIFF
--- a/metrics.coffee
+++ b/metrics.coffee
@@ -83,9 +83,11 @@ module.exports = Metrics =
 		if process.env['DEBUG_METRICS']
 			console.log("doing inc", key, opts)
 
-	count : (key, count, sampleRate = 1)->
+	count : (key, count, sampleRate = 1, opts = {})->
 		key = Metrics.buildPromKey(key)
-		prom.metric('counter', key).inc({app: appname, host: hostname}, count)
+		opts.app = appname
+		opts.host = hostname
+		prom.metric('counter', key).inc(opts, count)
 		if process.env['DEBUG_METRICS']
 			console.log("doing count/inc", key, opts)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Extend the `count` method to support additional options, as the `inc` method already does.