### PR TITLE
avoid step effects in summary metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",

--- a/prom_wrapper.coffee
+++ b/prom_wrapper.coffee
@@ -55,7 +55,7 @@ class MetricWrapper
 				new prom.Summary({
 					name: name,
 					help: name,
-					maxAgeSeconds: 600,
+					maxAgeSeconds: 60,
 					ageBuckets: 10,
 					labelNames: ['app', 'host', 'path', 'status_code', 'method', 'collection', 'query']
 				})


### PR DESCRIPTION
Finally reduce the prometheus summary window size from 10 minutes to 1 minute,  so that short spikes do not cause a 10 minute long "table" graph.  Only the percentile metrics are affected by this problem.

![docstore Set   Get doc 99% times](https://user-images.githubusercontent.com/7457354/76334986-c2027900-62eb-11ea-9f5c-c42dc3773d4a.png)

cc @gh2k 

Original issue https://github.com/overleaf/issues/issues/2263