### PR TITLE
Send HTTP request size metric

### DIFF
--- a/http.coffee
+++ b/http.coffee
@@ -17,7 +17,7 @@ module.exports.monitor = (logger) ->
 				routePath = req.route.path.toString().replace(/\//g, '_').replace(/\:/g, '').slice(1)
 				Metrics.timing("http_request", responseTimeMs, null, {method:req.method, status_code: res.statusCode, path:routePath})
 				if requestSize
-					Metrics.summary("http_request_size_bytes", requestSize, {method:req.method, path:routePath})
+					Metrics.summary("http_request_size_bytes", requestSize, {method:req.method, status_code: res.statusCode, path:routePath})
 				remoteIp = req.ip || req.socket?.socket?.remoteAddress || req.socket?.remoteAddress
 				reqUrl = req.originalUrl || req.url
 				referrer = req.headers['referer'] || req.headers['referrer']

--- a/http.coffee
+++ b/http.coffee
@@ -12,9 +12,12 @@ module.exports.monitor = (logger) ->
 			end.apply(this, arguments)
 			responseTime = process.hrtime(startTime)
 			responseTimeMs = Math.round(responseTime[0] * 1000 + responseTime[1] / 1000)
+			requestSize = parseInt(req.headers["content-length"], 10)
 			if req.route?.path?
 				routePath = req.route.path.toString().replace(/\//g, '_').replace(/\:/g, '').slice(1)
 				Metrics.timing("http_request", responseTimeMs, null, {method:req.method, status_code: res.statusCode, path:routePath})
+				if requestSize
+					Metrics.summary("http_request_size_bytes", requestSize, {method:req.method, path:routePath})
 				remoteIp = req.ip || req.socket?.socket?.remoteAddress || req.socket?.remoteAddress
 				reqUrl = req.originalUrl || req.url
 				referrer = req.headers['referer'] || req.headers['referrer']
@@ -23,7 +26,7 @@ module.exports.monitor = (logger) ->
 						httpRequest:
 							requestMethod: req.method
 							requestUrl: reqUrl
-							requestSize: req.headers["content-length"]
+							requestSize: requestSize
 							status: res.statusCode
 							responseSize: res._headers?["content-length"]
 							userAgent: req.headers["user-agent"]

--- a/metrics.coffee
+++ b/metrics.coffee
@@ -91,6 +91,14 @@ module.exports = Metrics =
 		if process.env['DEBUG_METRICS']
 			console.log("doing count/inc", key, opts)
 
+	summary : (key, value, opts = {})->
+		key = Metrics.buildPromKey(key)
+		opts.app = appname
+		opts.host = hostname
+		prom.metric('summary', key).observe(opts, value)
+		if process.env['DEBUG_METRICS']
+			console.log("doing summary", key, value, opts)
+
 	timing: (key, timeSpan, sampleRate, opts = {})->
 		key = Metrics.buildPromKey("timer_" + key)
 		opts.app = appname

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",

--- a/statsd/metrics.coffee
+++ b/statsd/metrics.coffee
@@ -29,6 +29,9 @@ module.exports = Metrics =
 	count : (key, count, sampleRate = 1)->
 		statsd.count buildKey(key), count, sampleRate
 
+	summary : (key, value)->
+		# not supported
+
 	timing: (key, timeSpan, sampleRate)->
 		statsd.timing(buildKey(key), timeSpan, sampleRate)
 


### PR DESCRIPTION
The metric is a "summary" called http_request_size_bytes.

The initial motivation for adding it is to figure out which endpoints get large requests (see https://github.com/overleaf/web-internal/pull/2666)