### PR TITLE
Downgrade all request logs to INFO

### DIFF
--- a/http.coffee
+++ b/http.coffee
@@ -49,10 +49,5 @@ module.exports.monitor = (logger) ->
 							"content-length": res._headers?["content-length"]
 							statusCode: res.statusCode
 						"response-time": responseTimeMs
-				if res.statusCode >= 500
-					logger.error(info, "%s %s", req.method, reqUrl)
-				else if res.statusCode >= 400 and res.statusCode < 500
-					logger.warn(info, "%s %s", req.method, reqUrl)
-				else
-					logger.info(info, "%s %s", req.method, reqUrl)
+				logger.info(info, "%s %s", req.method, reqUrl)
 		next()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "2.5.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Commit 9056143fe36f1347a1ff985ef8592a1de7d798dd added logic to log
requests with different error levels depending on the status code. The
intention was to make the 5xx and 4xx requests stand out in Stackdriver.
Unfortunately, this also creates a lot of noise in Sentry since we log
the errors separately from the requests.

This commit brings back the former behaviour of logging all requests at
the INFO level. We can revisit this if we integrate the strategy
implemented in filestore of logging once per request.