### PR TITLE
[misc] enable compression for the /metrics route

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@
 let Metrics;
 console.log("using prometheus");
 
+const ExpressCompression = require('compression');
 const prom = require('./prom_wrapper');
 
 const {
@@ -75,7 +76,9 @@ module.exports = (Metrics = {
 	},
 
 	injectMetricsRoute(app) {
-		return app.get('/metrics', function(req, res) {
+		return app.get('/metrics', ExpressCompression({
+			level: parseInt(process.env.METRICS_COMPRESSION_LEVEL || '1', 10)
+		}), function (req, res) {
 			res.set('Content-Type', prom.registry.contentType);
 			return res.end(prom.registry.metrics());
 		});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@google-cloud/debug-agent": "^3.0.0",
     "@google-cloud/profiler": "^0.2.3",
     "@google-cloud/trace-agent": "^3.2.0",
+    "compression": "^1.7.4",
     "prom-client": "^11.1.3",
     "underscore": "~1.6.0",
     "yn": "^3.1.1"


### PR DESCRIPTION
For https://github.com/overleaf/issues/issues/2889

```
$ curl http://127.0.0.1:3012/metrics | wc -c
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8061    0  8061    0     0  7872k      0 --:--:-- --:--:-- --:--:-- 7872k
8061

$ curl http://127.0.0.1:3012/metrics --compressed | wc -c
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1494    0  1494    0     0  1458k      0 --:--:-- --:--:-- --:--:-- 1458k
8078

#    ^^^^ total transferred bytes went down to 1494
``` 