### PR TITLE
Log requests that don't have a route property

### DIFF
--- a/http.coffee
+++ b/http.coffee
@@ -18,36 +18,36 @@ module.exports.monitor = (logger) ->
 				Metrics.timing("http_request", responseTimeMs, null, {method:req.method, status_code: res.statusCode, path:routePath})
 				if requestSize
 					Metrics.summary("http_request_size_bytes", requestSize, {method:req.method, status_code: res.statusCode, path:routePath})
-				remoteIp = req.ip || req.socket?.socket?.remoteAddress || req.socket?.remoteAddress
-				reqUrl = req.originalUrl || req.url
-				referrer = req.headers['referer'] || req.headers['referrer']
-				if STACKDRIVER_LOGGING
-					info =
-						httpRequest:
-							requestMethod: req.method
-							requestUrl: reqUrl
-							requestSize: requestSize
-							status: res.statusCode
-							responseSize: res._headers?["content-length"]
-							userAgent: req.headers["user-agent"]
-							remoteIp: remoteIp
-							referer: referrer
-							latency:
-								seconds: responseTime[0]
-								nanos: responseTime[1]
-							protocol: req.protocol
-				else
-					info =
-						req:
-							url: reqUrl
-							method: req.method
-							referrer: referrer
-							"remote-addr": remoteIp
-							"user-agent": req.headers["user-agent"]
-							"content-length": req.headers["content-length"]
-						res:
-							"content-length": res._headers?["content-length"]
-							statusCode: res.statusCode
-						"response-time": responseTimeMs
-				logger.info(info, "%s %s", req.method, reqUrl)
+			remoteIp = req.ip || req.socket?.socket?.remoteAddress || req.socket?.remoteAddress
+			reqUrl = req.originalUrl || req.url
+			referrer = req.headers['referer'] || req.headers['referrer']
+			if STACKDRIVER_LOGGING
+				info =
+					httpRequest:
+						requestMethod: req.method
+						requestUrl: reqUrl
+						requestSize: requestSize
+						status: res.statusCode
+						responseSize: res._headers?["content-length"]
+						userAgent: req.headers["user-agent"]
+						remoteIp: remoteIp
+						referer: referrer
+						latency:
+							seconds: responseTime[0]
+							nanos: responseTime[1]
+						protocol: req.protocol
+			else
+				info =
+					req:
+						url: reqUrl
+						method: req.method
+						referrer: referrer
+						"remote-addr": remoteIp
+						"user-agent": req.headers["user-agent"]
+						"content-length": req.headers["content-length"]
+					res:
+						"content-length": res._headers?["content-length"]
+						statusCode: res.statusCode
+					"response-time": responseTimeMs
+			logger.info(info, "%s %s", req.method, reqUrl)
 		next()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The v1 history service has its routes set up via swagger-tools, which doesn't write a route property on the request. This prevents us to send request metrics based on the route, but we can still log the request.

Previously, we would skip both metrics and logging when a request doesn't have a route property. With this PR, we only skip metrics.