### PR TITLE
[http] use public node api for getting the response content-length

### DIFF
--- a/http.js
+++ b/http.js
@@ -39,7 +39,7 @@ module.exports.monitor = logger => (function(req, res, next) {
                     requestUrl: reqUrl,
                     requestSize,
                     status: res.statusCode,
-                    responseSize: (res._headers != null ? res._headers["content-length"] : undefined),
+                    responseSize: res.getHeader("content-length"),
                     userAgent: req.headers["user-agent"],
                     remoteIp,
                     referer: referrer,
@@ -61,7 +61,7 @@ module.exports.monitor = logger => (function(req, res, next) {
                     "content-length": req.headers["content-length"]
                 },
                 res: {
-                    "content-length": (res._headers != null ? res._headers["content-length"] : undefined),
+                    "content-length": res.getHeader("content-length"),
                     statusCode: res.statusCode
                 },
                 "response-time": responseTimeMs


### PR DESCRIPTION
[Accessing `OutgoingMessage._headers` triggers a deprecation warning](https://github.com/nodejs/node/blob/42a3a7f97d3b565763671047c774c858c1e0d5c1/lib/_http_outgoing.js#L169-L172).

There is a public api method available for getting a response header: [`getHeader` added in `v0.4.0`](https://nodejs.org/docs/latest-v10.x/api/http.html#http_response_getheader_name).