### PR TITLE
Export a configured prom-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/metrics",
-  "version": "3.2.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/metrics",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",

--- a/prom_wrapper.js
+++ b/prom_wrapper.js
@@ -68,7 +68,7 @@ class MetricWrapper {
           return new prom.Counter({
             name,
             help: name,
-            labelNames: ['app', 'host', 'status', 'method', 'path']
+            labelNames: ['status', 'method', 'path']
           })
         case 'summary':
           return new prom.Summary({
@@ -76,21 +76,13 @@ class MetricWrapper {
             help: name,
             maxAgeSeconds: 60,
             ageBuckets: 10,
-            labelNames: [
-              'app',
-              'host',
-              'path',
-              'status_code',
-              'method',
-              'collection',
-              'query'
-            ]
+            labelNames: ['path', 'status_code', 'method', 'collection', 'query']
           })
         case 'gauge':
           return new prom.Gauge({
             name,
             help: name,
-            labelNames: ['app', 'host', 'status']
+            labelNames: ['host', 'status']
           })
       }
     })()

--- a/test/acceptance/metrics_tests.js
+++ b/test/acceptance/metrics_tests.js
@@ -80,7 +80,7 @@ describe('Metrics module', function() {
       Metrics.globalGauge('tire_pressure', 99.99)
       const { value, labels } = await getMetricValue('tire_pressure')
       expect(value).to.equal(99.99)
-      expect(labels.host).to.equal('')
+      expect(labels.host).to.equal('global')
       expect(labels.app).to.equal(APP_NAME)
     })
   })
@@ -102,9 +102,9 @@ async function getSummarySum(key) {
 }
 
 async function getMetricValue(key) {
-  const metric = getMetric(key)
-  const item = await metric.get()
-  return item.values[0]
+  const metrics = await Metrics.register.getMetricsAsJSON()
+  const metric = metrics.find(m => m.name === key)
+  return metric.values[0]
 }
 
 async function expectMetricValue(key, expectedValue) {


### PR DESCRIPTION
Metrics.initialize() and Metrics.configure() will configure the default Prometheus registry with default "app" and "host" labels. The configured prom-client module is available as Metrics.prom.

I initially thought of using [multiple registries](https://github.com/siimon/prom-client#multiple-registries) with different default values to handle the `globalGauge` metric, but it makes things more complicated, and it defeats the protection against multiple metrics with the same name. Instead, global gauges will have the `host` label set to "global".

Issue: https://github.com/overleaf/issues/issues/3672

- [x] Tested in web as part of  overleaf/web-internal#3302.