### PR TITLE
[misc] fix collection of open sockets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/metrics",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/metrics",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",

--- a/test/acceptance/metrics_tests.js
+++ b/test/acceptance/metrics_tests.js
@@ -1,4 +1,5 @@
 const os = require('os')
+const http = require('http')
 const { expect } = require('chai')
 const Metrics = require('../..')
 
@@ -84,6 +85,129 @@ describe('Metrics module', function() {
       expect(labels.app).to.equal(APP_NAME)
     })
   })
+
+  describe('open_sockets', function() {
+    const keyServer1 = 'open_connections_http_127_42_42_1'
+    const keyServer2 = 'open_connections_http_127_42_42_2'
+
+    let finish1, finish2, emitResponse1, emitResponse2
+    function resetEmitResponse1() {
+      emitResponse1 = new Promise(resolve => (finish1 = resolve))
+    }
+    resetEmitResponse1()
+    function resetEmitResponse2() {
+      emitResponse2 = new Promise(resolve => (finish2 = resolve))
+    }
+    resetEmitResponse2()
+
+    let server1, server2
+    before(function setupServer1(done) {
+      server1 = http.createServer((req, res) => {
+        res.write('...')
+        emitResponse1.then(() => res.end())
+      })
+      server1.listen(0, '127.42.42.1', done)
+    })
+    before(function setupServer2(done) {
+      server2 = http.createServer((req, res) => {
+        res.write('...')
+        emitResponse2.then(() => res.end())
+      })
+      server2.listen(0, '127.42.42.2', done)
+    })
+    after(function cleanupPendingRequests() {
+      finish1()
+      finish2()
+    })
+    after(function shutdownServer1(done) {
+      if (server1) server1.close(done)
+    })
+    after(function shutdownServer2(done) {
+      if (server2) server2.close(done)
+    })
+
+    let urlServer1, urlServer2
+    before(function setUrls() {
+      urlServer1 = `http://127.42.42.1:${server1.address().port}/`
+      urlServer2 = `http://127.42.42.2:${server2.address().port}/`
+    })
+    describe('gaugeOpenSockets()', function() {
+      beforeEach(function runGaugeOpenSockets() {
+        Metrics.open_sockets.gaugeOpenSockets()
+      })
+
+      describe('without pending connections', function() {
+        it('emits no open_connections', async function() {
+          await expectNoMetricValue(keyServer1)
+          await expectNoMetricValue(keyServer2)
+        })
+      })
+
+      describe('with pending connections for server1', function() {
+        before(function(done) {
+          http.get(urlServer1)
+          http.get(urlServer1)
+          setTimeout(done, 10)
+        })
+
+        it('emits 2 open_connections for server1', async function() {
+          await expectMetricValue(keyServer1, 2)
+        })
+
+        it('emits no open_connections for server2', async function() {
+          await expectNoMetricValue(keyServer2)
+        })
+      })
+
+      describe('with pending connections for server1 and server2', function() {
+        before(function(done) {
+          http.get(urlServer2)
+          http.get(urlServer2)
+          setTimeout(done, 10)
+        })
+
+        it('emits 2 open_connections for server1', async function() {
+          await expectMetricValue(keyServer1, 2)
+        })
+
+        it('emits 2 open_connections for server1', async function() {
+          await expectMetricValue(keyServer1, 2)
+        })
+      })
+
+      describe('when requests finish for server1', function() {
+        before(function(done) {
+          finish1()
+          resetEmitResponse1()
+          http.get(urlServer1)
+
+          setTimeout(done, 10)
+        })
+
+        it('emits 1 open_connections for server1', async function() {
+          await expectMetricValue(keyServer1, 1)
+        })
+
+        it('emits 2 open_connections for server2', async function() {
+          await expectMetricValue(keyServer2, 2)
+        })
+      })
+
+      describe('when all requests complete', function() {
+        before(function(done) {
+          finish1()
+          finish2()
+
+          setTimeout(done, 10)
+        })
+
+        it('emits no open_connections', async function() {
+          await expectNoMetricValue(keyServer1)
+          await expectNoMetricValue(keyServer2)
+        })
+      })
+    })
+  })
 })
 
 function getMetric(key) {
@@ -112,4 +236,10 @@ async function expectMetricValue(key, expectedValue) {
   expect(value.value).to.equal(expectedValue)
   expect(value.labels.host).to.equal(HOSTNAME)
   expect(value.labels.app).to.equal(APP_NAME)
+}
+
+async function expectNoMetricValue(key) {
+  const metric = getMetric(key)
+  if (!metric) return
+  await expectMetricValue(key, 0)
 }


### PR DESCRIPTION
#### Description

For https://github.com/overleaf/issues/issues/3652

This PR fixes two bugs as outlined in https://github.com/overleaf/issues/issues/3652

- url parsing is broken

  The keys in `require('http').globalAgent.sockets` are tuples separated by colons and have a trailing colon: `HOST:PORT:`. For the https agent there are even more empty fields `HOST:PORT::::::::::::::::::`.
  The trailing colon is breaking the url parsing with the builtin parser `require('url').URL`.

  This bug was introduced as part of the decaffeinate process. #35

- missing reset of gauges following no more open connections on a host

  We are using gauges with a metrics key per host.
  The metric for hosts that no longer receive traffic are not reset back to 0, but retain their previous value forever.

#### Related PRs

For https://github.com/overleaf/issues/issues/3652
#35 

#### Potential Impact

Low. Services opt-in to using the collection of open sockets. Services like clsi see unhandled exceptions w/o this patch.