### PR TITLE
[misc] drop idle background loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function initialize(appName, opts = {}) {
   appName = appName || DEFAULT_APP_NAME
   configure({ ...opts, appName })
   collectDefaultMetrics({ timeout: 5000, prefix: '' })
+  promWrapper.setupSweeping()
 
   console.log(`ENABLE_TRACE_AGENT set to ${process.env.ENABLE_TRACE_AGENT}`)
   if (process.env.ENABLE_TRACE_AGENT === 'true') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/metrics",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/metrics",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",

--- a/prom_wrapper.js
+++ b/prom_wrapper.js
@@ -138,12 +138,15 @@ class MetricWrapper {
   }
 }
 
-if (!PromWrapper.sweepRegistered) {
+let sweepingInterval
+PromWrapper.setupSweeping = function() {
+  if (sweepingInterval) {
+    clearInterval(sweepingInterval)
+  }
   if (process.env.DEBUG_METRICS) {
     console.log('Registering sweep method')
   }
-  PromWrapper.sweepRegistered = true
-  setInterval(function() {
+  sweepingInterval = setInterval(function() {
     if (PromWrapper.ttlInMinutes) {
       if (process.env.DEBUG_METRICS) {
         console.log('Sweeping metrics')
@@ -153,6 +156,9 @@ if (!PromWrapper.sweepRegistered) {
       })
     }
   }, 60000)
+
+  const Metrics = require('./index')
+  Metrics.registerDestructor(() => clearInterval(sweepingInterval))
 }
 
 module.exports = PromWrapper

--- a/prom_wrapper.js
+++ b/prom_wrapper.js
@@ -143,18 +143,22 @@ PromWrapper.setupSweeping = function() {
   if (sweepingInterval) {
     clearInterval(sweepingInterval)
   }
+  if (!PromWrapper.ttlInMinutes) {
+    if (process.env.DEBUG_METRICS) {
+      console.log('Not registering sweep method -- empty ttl')
+    }
+    return
+  }
   if (process.env.DEBUG_METRICS) {
     console.log('Registering sweep method')
   }
   sweepingInterval = setInterval(function() {
-    if (PromWrapper.ttlInMinutes) {
-      if (process.env.DEBUG_METRICS) {
-        console.log('Sweeping metrics')
-      }
-      return metrics.forEach((metric, key) => {
-        return metric.sweep()
-      })
+    if (process.env.DEBUG_METRICS) {
+      console.log('Sweeping metrics')
     }
+    return metrics.forEach((metric, key) => {
+      return metric.sweep()
+    })
   }, 60000)
 
   const Metrics = require('./index')


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3764

This PR is changing the registration of a polling background process what may sweep old metrics from the registry.

The config for the sweeping is specified during the `metrics.initialize` call and we can conditionally active the background process in case it's actually requested.

The background process is now registered for cleanup.

### Review

This is best reviewed without whitespace changes.

### Related issues


For https://github.com/overleaf/issues/issues/3764
https://github.com/overleaf/metrics-module/pull/20

### Manual testing performed

The CI pipeline of analytics and project-history is passing without the `--exit` flag now.

- analytics https://github.com/overleaf/analytics/commit/458d53bc85f5cbbc0701d57c6dc22011b7203240 https://console.cloud.google.com/cloud-build/builds/9fe43592-2250-446c-8b0d-c32b83fdb576?project=overleaf-ops
- project-history https://github.com/overleaf/project-history/commit/415fbea69c36f7eb5bdbc734ab87175f100778fc https://console.cloud.google.com/cloud-build/builds/343a9884-2a23-4ace-9390-41df86c4e605?project=overleaf-ops